### PR TITLE
fix: string3.rs 注释提示不准确

### DIFF
--- a/exercises/09_strings/strings3.rs
+++ b/exercises/09_strings/strings3.rs
@@ -3,7 +3,7 @@ fn trim_me(input: &str) -> &str {
 }
 
 fn compose_me(input: &str) -> String {
-    // TODO: 在字符串后面添加 "world!" ，有很多方法可以做到这一点。
+    // TODO: 在字符串后面添加 " world!" ，有很多方法可以做到这一点。
 }
 
 fn replace_me(input: &str) -> String {


### PR DESCRIPTION
按照要求，`compose_me` 函数的功能应为在字符串后添加`" world!"`，原来的提示注释中少一个空格。